### PR TITLE
Issue #6: Public board page (incl. bounties schema)

### DIFF
--- a/drizzle/0001_bounties.sql
+++ b/drizzle/0001_bounties.sql
@@ -1,0 +1,81 @@
+CREATE TYPE "bounty_state" AS ENUM (
+	'draft',
+	'in_review',
+	'open',
+	'judging',
+	'resolved',
+	'unresolved',
+	'hidden'
+);
+--> statement-breakpoint
+
+CREATE TYPE "moderation_status" AS ENUM (
+	'approved',
+	'needs_review',
+	'hidden_pending_review',
+	'rejected'
+);
+--> statement-breakpoint
+
+CREATE TYPE "bounty_category" AS ENUM (
+	'tiny_web_app',
+	'game_or_toy',
+	'visual_experiment',
+	'ai_experiment',
+	'productivity_tool',
+	'classroom_or_learning_tool',
+	'weird_internet_object',
+	'landing_page'
+);
+--> statement-breakpoint
+
+CREATE TABLE "bounties" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"author_id" uuid NOT NULL,
+	"title" text NOT NULL,
+	"category" "bounty_category" NOT NULL,
+	"deadline" timestamp with time zone NOT NULL,
+	"desired_output_type" text NOT NULL,
+	"prompt_description" text NOT NULL,
+	"acceptance_vibes" text NOT NULL,
+	"fun_factor" text,
+	"inspiration_links" jsonb,
+	"state" "bounty_state" DEFAULT 'open' NOT NULL,
+	"moderation_status" "moderation_status" DEFAULT 'approved' NOT NULL,
+	"moderation_reason" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+-- Hand-written below: drizzle-kit can't express cross-schema FKs to auth.users,
+-- nor Supabase RLS policies. Maintain alongside src/db/schema.ts.
+
+ALTER TABLE "bounties" ADD CONSTRAINT "bounties_author_id_fkey"
+	FOREIGN KEY ("author_id") REFERENCES "auth"."users"("id") ON DELETE CASCADE;
+--> statement-breakpoint
+
+ALTER TABLE public.bounties ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+
+-- Public bounties (approved + visible states) are readable by everyone.
+-- Authors can also see their own bounties in any state (including drafts and hidden).
+CREATE POLICY "Bounties are viewable when public or by author"
+	ON public.bounties FOR SELECT
+	USING (
+		(
+			state IN ('open', 'judging', 'resolved', 'unresolved')
+			AND moderation_status = 'approved'
+		)
+		OR auth.uid() = author_id
+	);
+--> statement-breakpoint
+
+CREATE POLICY "Authenticated users can insert their own bounties"
+	ON public.bounties FOR INSERT
+	WITH CHECK (auth.uid() = author_id);
+--> statement-breakpoint
+
+CREATE POLICY "Authors can update their own bounties"
+	ON public.bounties FOR UPDATE
+	USING (auth.uid() = author_id)
+	WITH CHECK (auth.uid() = author_id);

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -1,0 +1,65 @@
+import Link from "next/link";
+import { cookies } from "next/headers";
+import { eq } from "drizzle-orm";
+import { createClient } from "@/utils/supabase/server";
+import { db } from "@/db";
+import { profiles } from "@/db/schema";
+import { logout } from "@/app/me/actions";
+
+export default async function Header() {
+  const cookieStore = await cookies();
+  const supabase = createClient(cookieStore);
+  const { data, error } = await supabase.auth.getUser();
+  const user = error ? null : data.user;
+
+  let greeting: string | null = null;
+  if (user) {
+    const rows = await db
+      .select({ displayName: profiles.displayName })
+      .from(profiles)
+      .where(eq(profiles.id, user.id))
+      .limit(1);
+    greeting = rows[0]?.displayName ?? user.email ?? "there";
+  }
+
+  return (
+    <header
+      style={{
+        display: "flex",
+        flexWrap: "wrap",
+        gap: "1rem",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "1rem",
+        borderBottom: "1px solid #ddd",
+      }}
+    >
+      <Link
+        href="/"
+        style={{ fontWeight: 700, fontSize: "1.1rem", textDecoration: "none" }}
+      >
+        AI Bounty Board
+      </Link>
+      <nav
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "1rem",
+          alignItems: "center",
+        }}
+      >
+        <a href="/bounties/new">Post a bounty</a>
+        {user ? (
+          <>
+            <span>Hello, {greeting}</span>
+            <form action={logout} style={{ margin: 0 }}>
+              <button type="submit">Log out</button>
+            </form>
+          </>
+        ) : (
+          <a href="/login">Log in</a>
+        )}
+      </nav>
+    </header>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,104 @@
-export default function Home() {
+import { and, desc, eq, inArray } from "drizzle-orm";
+import { db } from "@/db";
+import { bounties } from "@/db/schema";
+import Header from "@/app/components/Header";
+
+const MAX_ROWS = 100;
+
+export default async function Home() {
+  const rows = await db
+    .select({
+      id: bounties.id,
+      title: bounties.title,
+      category: bounties.category,
+      deadline: bounties.deadline,
+      desiredOutputType: bounties.desiredOutputType,
+      state: bounties.state,
+    })
+    .from(bounties)
+    .where(
+      and(
+        inArray(bounties.state, ["open", "judging", "resolved", "unresolved"]),
+        eq(bounties.moderationStatus, "approved"),
+      ),
+    )
+    .orderBy(desc(bounties.createdAt))
+    .limit(MAX_ROWS);
+
   return (
-    <main style={{ maxWidth: 480, margin: "4rem auto", padding: "0 1rem" }}>
-      <h1>AI Bounty Board</h1>
-      <p>
-        A retro pixel-art western board where folks post fun build prompts and
-        vibe coders ship public demos in response.
-      </p>
-      <p>
-        <a href="/signup">Sign up</a> · <a href="/login">Log in</a>
-      </p>
-    </main>
+    <>
+      <Header />
+      <main style={{ maxWidth: 960, margin: "2rem auto", padding: "0 1rem" }}>
+        <h1>Board</h1>
+        {rows.length === 0 ? (
+          <section
+            style={{
+              padding: "2rem",
+              textAlign: "center",
+              border: "1px dashed #ccc",
+              borderRadius: 8,
+              marginTop: "1rem",
+            }}
+          >
+            <p>No bounties yet. Be the first to post one.</p>
+            <p>
+              <a href="/bounties/new">Post a bounty</a>
+            </p>
+          </section>
+        ) : (
+          <ul
+            style={{
+              listStyle: "none",
+              padding: 0,
+              display: "grid",
+              gap: "1rem",
+              gridTemplateColumns: "repeat(auto-fill, minmax(260px, 1fr))",
+              marginTop: "1rem",
+            }}
+          >
+            {rows.map((b) => (
+              <li key={b.id}>
+                <a
+                  href={`/bounties/${b.id}`}
+                  style={{
+                    display: "block",
+                    padding: "1rem",
+                    border: "1px solid #ddd",
+                    borderRadius: 8,
+                    textDecoration: "none",
+                    color: "inherit",
+                  }}
+                >
+                  <h2 style={{ margin: "0 0 0.5rem", fontSize: "1.1rem" }}>
+                    {b.title}
+                  </h2>
+                  <dl
+                    style={{
+                      margin: 0,
+                      display: "grid",
+                      gridTemplateColumns: "auto 1fr",
+                      columnGap: "0.5rem",
+                      rowGap: "0.25rem",
+                      fontSize: "0.9rem",
+                    }}
+                  >
+                    <dt>Category</dt>
+                    <dd style={{ margin: 0 }}>{b.category}</dd>
+                    <dt>Deadline</dt>
+                    <dd style={{ margin: 0 }}>
+                      {b.deadline.toISOString().slice(0, 10)}
+                    </dd>
+                    <dt>Output</dt>
+                    <dd style={{ margin: 0 }}>{b.desiredOutputType}</dd>
+                    <dt>State</dt>
+                    <dd style={{ margin: 0 }}>{b.state}</dd>
+                  </dl>
+                </a>
+              </li>
+            ))}
+          </ul>
+        )}
+      </main>
+    </>
   );
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, jsonb, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, pgEnum, uuid, text, jsonb, timestamp } from "drizzle-orm/pg-core";
 
 // Mirrors auth.users — FK to auth.users(id) is added in the migration SQL by hand,
 // since drizzle-kit can't express cross-schema FKs to Supabase's managed auth schema.
@@ -8,6 +8,64 @@ export const profiles = pgTable("profiles", {
   avatarUrl: text("avatar_url"),
   bio: text("bio"),
   links: jsonb("links"),
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
+// PRD §15
+export const bountyState = pgEnum("bounty_state", [
+  "draft",
+  "in_review",
+  "open",
+  "judging",
+  "resolved",
+  "unresolved",
+  "hidden",
+]);
+
+// AGENTS.md schema rules — moderation fields exist from day 1 even though
+// AI moderation is deferred to post-v0.
+export const moderationStatus = pgEnum("moderation_status", [
+  "approved",
+  "needs_review",
+  "hidden_pending_review",
+  "rejected",
+]);
+
+// PRD §26
+export const bountyCategory = pgEnum("bounty_category", [
+  "tiny_web_app",
+  "game_or_toy",
+  "visual_experiment",
+  "ai_experiment",
+  "productivity_tool",
+  "classroom_or_learning_tool",
+  "weird_internet_object",
+  "landing_page",
+]);
+
+// FK to auth.users(id) ON DELETE CASCADE is added in the migration SQL by hand.
+// RLS policies live in the migration too — drizzle-kit can't express either.
+export const bounties = pgTable("bounties", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  authorId: uuid("author_id").notNull(),
+  title: text("title").notNull(),
+  category: bountyCategory("category").notNull(),
+  deadline: timestamp("deadline", { withTimezone: true }).notNull(),
+  desiredOutputType: text("desired_output_type").notNull(),
+  promptDescription: text("prompt_description").notNull(),
+  acceptanceVibes: text("acceptance_vibes").notNull(),
+  funFactor: text("fun_factor"),
+  inspirationLinks: jsonb("inspiration_links").$type<string[]>(),
+  state: bountyState("state").notNull().default("open"),
+  moderationStatus: moderationStatus("moderation_status")
+    .notNull()
+    .default("approved"),
+  moderationReason: text("moderation_reason"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .defaultNow()
     .notNull(),


### PR DESCRIPTION
Closes #6

## Summary
- `drizzle/0001_bounties.sql` migration: PRD §11 fields + state/moderation enums per AGENTS.md schema rules
- `/` replaced with server component querying bounties (empty state in v0)
- `Header` component with auth-aware nav

## Scope widening rationale

Issue #6 assumed a `bounties` table exists, but it didn't. Per `AGENTS.md` "Schema rules that must hold from day 1", bounties needs the full schema in migration #1, not a stub. So this PR lands the migration alongside the board page. Issue #7 then only adds the post-a-bounty form + write paths.

## Schema decisions
- Used Postgres enums (`pgEnum`) for `bounty_state`, `moderation_status`, and `bounty_category` rather than `text` + check constraints — enums match the existing migration style and give cleaner Drizzle inference. Trade-off: adding/removing a value later requires `ALTER TYPE` instead of editing a check.
- Cross-schema FK to `auth.users(id) ON DELETE CASCADE` is hand-written below the `--> statement-breakpoint` divider, mirroring `0000_init.sql`.
- RLS policies:
  - SELECT: public when `state IN ('open','judging','resolved','unresolved')` AND `moderation_status = 'approved'`, OR `auth.uid() = author_id` so authors see their drafts/hidden rows. Sheriff visibility is deferred to #13.
  - INSERT: `WITH CHECK (auth.uid() = author_id)`.
  - UPDATE: `USING / WITH CHECK (auth.uid() = author_id)`. (#13 will refine to gate by `state` once moderation lands.)
  - No DELETE policy — disallowed in v0.
- `inspirationLinks` typed as `jsonb` with `$type<string[]>()` in the Drizzle schema.

## Test plan
- [ ] Apply migration locally (`npx drizzle-kit migrate`) — table exists with all columns
- [ ] Visit `/` signed-out — see empty state, no `/login` redirect
- [ ] Visit `/` signed-in — header shows greeting + Logout
- [ ] Click "Post a bounty" — currently 404 (issue #7 lands the route)

## Caveats
- `npm run lint` is green; `npx tsc --noEmit` is clean.
- `npm run build` could not be verified end-to-end in this worktree: the pre-existing `next/font/google` Geist + Geist Mono fetches in `src/app/layout.tsx` fail because the sandbox cannot reach `fonts.googleapis.com`. The failure is unrelated to anything in this PR. Verify locally / on Vercel where Google Fonts is reachable.
- The migration SQL was hand-written and not run through `pg_format`. Reviewer should sanity-check syntax before applying — particularly the enum values and the multi-line policy bodies.