### PR TITLE
fix: compute effective bounty deadline states

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "tsx --test tests/*.test.ts"
   },
   "dependencies": {
     "@supabase/ssr": "^0.10.2",

--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { bounties } from "@/lib/mock-data";
+import { effectiveBountyState } from "@/lib/bounty-state";
 import { StatusBadge } from "@/components/status-badge";
 
 const tabs = ["Overview", "Requirements", "Deliverables", "Judging"];
@@ -20,6 +21,14 @@ const examples = [
 export default async function BountyDetail({ params }: { params: Promise<{ id: string }> }) {
   const { id } = await params;
   const bounty = bounties.find((b) => b.id === id) ?? bounties[0];
+  const persistedState = bounty.status === "completed" ? "resolved" : bounty.status;
+  const effectiveStatus = effectiveBountyState({ state: persistedState, deadline: bounty.deadline });
+  const timeRemaining =
+    effectiveStatus === "open" ? `${bounty.daysLeft}d 12h 45m 18s` :
+    effectiveStatus === "judging" ? "Judging now" :
+    effectiveStatus === "unresolved" ? "Unresolved" :
+    effectiveStatus === "resolved" ? "Resolved" :
+    effectiveStatus;
 
   const thumbGradients: Record<string, string> = {
     "🌤️": "from-amber-900/60 to-yellow-900/40",
@@ -49,7 +58,7 @@ export default async function BountyDetail({ params }: { params: Promise<{ id: s
             <div>
               <div className="flex flex-wrap items-center gap-2.5 mb-1.5">
                 <h1 className="text-[26px] font-bold text-cream leading-tight">{bounty.title}</h1>
-                <StatusBadge status={bounty.status} />
+                <StatusBadge status={effectiveStatus} />
               </div>
               <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-[11px] font-semibold border border-gold-muted/40 text-gold-muted">
                 {bounty.category}
@@ -161,7 +170,7 @@ export default async function BountyDetail({ params }: { params: Promise<{ id: s
             <div className="text-center mb-4">
               <div className="text-[11px] text-sand mb-1">Time Remaining</div>
               <div className="text-[24px] font-bold text-gold tracking-tight">
-                {bounty.daysLeft}d 12h 45m 18s
+                {timeRemaining}
               </div>
               <div className="text-[11px] text-dust mt-0.5">Deadline: {bounty.deadline}</div>
             </div>

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
@@ -17,7 +18,7 @@ export default async function MePage() {
         <small>User id: {data.user.id}</small>
       </p>
       <p>
-        <a href="/profile">Edit profile (placeholder)</a>
+        <Link href="/profile">Edit profile (placeholder)</Link>
       </p>
       <form action={logout}>
         <button type="submit">Log out</button>

--- a/src/components/bounty-card.tsx
+++ b/src/components/bounty-card.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import type { Bounty } from "@/lib/mock-data";
+import { effectiveBountyState } from "@/lib/bounty-state";
 import { StatusBadge } from "./status-badge";
 
 const thumbGradients: Record<string, string> = {
@@ -32,6 +33,14 @@ function CategoryTag({ category }: { category: string }) {
 
 export function BountyCard({ bounty }: { bounty: Bounty }) {
   const grad = thumbGradients[bounty.icon] ?? "from-stone-800/60 to-stone-900/40";
+  const persistedState = bounty.status === "completed" ? "resolved" : bounty.status;
+  const effectiveStatus = effectiveBountyState({ state: persistedState, deadline: bounty.deadline });
+  const timeLabel =
+    effectiveStatus === "open" ? `${bounty.daysLeft} days left` :
+    effectiveStatus === "judging" ? "Judging now" :
+    effectiveStatus === "unresolved" ? "Unresolved" :
+    effectiveStatus === "resolved" ? "Resolved" :
+    bounty.status;
 
   return (
     <Link href={`/bounties/${bounty.id}`} className="group block">
@@ -74,7 +83,7 @@ export function BountyCard({ bounty }: { bounty: Bounty }) {
               <svg className="w-3.5 h-3.5 text-dust" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                 <path strokeLinecap="round" strokeLinejoin="round" d="M12 6v6l4 2m6-2a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              {bounty.daysLeft} days left
+              {timeLabel}
             </span>
             <span className="flex items-center gap-1">
               <svg className="w-3.5 h-3.5 text-dust" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -83,7 +92,7 @@ export function BountyCard({ bounty }: { bounty: Bounty }) {
               {bounty.rangersCount} Rangers
             </span>
           </div>
-          <StatusBadge status={bounty.status} />
+          <StatusBadge status={effectiveStatus} />
         </div>
       </div>
     </Link>

--- a/src/components/status-badge.tsx
+++ b/src/components/status-badge.tsx
@@ -1,11 +1,14 @@
 import type { BountyStatus } from "@/lib/mock-data";
 
 const config: Record<BountyStatus, { label: string; bg: string; text: string; dot: string }> = {
+  draft: { label: "Draft", bg: "bg-dust/15", text: "text-dust", dot: "bg-dust" },
+  in_review: { label: "In Review", bg: "bg-info/15", text: "text-info", dot: "bg-info" },
   open: { label: "Open", bg: "bg-success/15", text: "text-success", dot: "bg-success" },
   judging: { label: "Judging", bg: "bg-warning/15", text: "text-warning", dot: "bg-warning" },
+  resolved: { label: "Resolved", bg: "bg-gold/15", text: "text-gold", dot: "bg-gold" },
   completed: { label: "Completed", bg: "bg-gold/15", text: "text-gold", dot: "bg-gold" },
-  draft: { label: "Draft", bg: "bg-dust/15", text: "text-dust", dot: "bg-dust" },
   unresolved: { label: "Unresolved", bg: "bg-danger/15", text: "text-danger", dot: "bg-danger" },
+  hidden: { label: "Hidden", bg: "bg-dust/15", text: "text-dust", dot: "bg-dust" },
 };
 
 const submissionConfig: Record<string, { label: string; bg: string; text: string; dot: string }> = {

--- a/src/lib/bounty-state.ts
+++ b/src/lib/bounty-state.ts
@@ -1,0 +1,69 @@
+export const JUDGING_WINDOW_DAYS = 14;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type BountyLifecycleState =
+  | "draft"
+  | "in_review"
+  | "open"
+  | "judging"
+  | "resolved"
+  | "unresolved"
+  | "hidden";
+
+export interface BountyStateInput {
+  state: BountyLifecycleState;
+  deadline: Date | string | number | null | undefined;
+  winnerSelected?: boolean | null;
+}
+
+export function parseBountyDeadline(deadline: BountyStateInput["deadline"]): Date | null {
+  if (deadline === null || deadline === undefined || deadline === "") {
+    return null;
+  }
+
+  const parsed = deadline instanceof Date ? deadline : new Date(deadline);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function judgingWindowEndsAt(deadline: BountyStateInput["deadline"]): Date | null {
+  const parsedDeadline = parseBountyDeadline(deadline);
+  if (!parsedDeadline) {
+    return null;
+  }
+
+  return new Date(parsedDeadline.getTime() + JUDGING_WINDOW_DAYS * MS_PER_DAY);
+}
+
+export function effectiveBountyState(
+  bounty: BountyStateInput,
+  now: Date = new Date(),
+): BountyLifecycleState {
+  const deadline = parseBountyDeadline(bounty.deadline);
+  if (!deadline) {
+    return bounty.state;
+  }
+
+  if (bounty.state === "open" && deadline.getTime() < now.getTime()) {
+    return "judging";
+  }
+
+  const judgingEndsAt = judgingWindowEndsAt(deadline);
+  if (
+    bounty.state === "judging" &&
+    !bounty.winnerSelected &&
+    judgingEndsAt !== null &&
+    judgingEndsAt.getTime() < now.getTime()
+  ) {
+    return "unresolved";
+  }
+
+  return bounty.state;
+}
+
+export function bountyNeedsStateWriteThrough(
+  bounty: BountyStateInput,
+  now: Date = new Date(),
+): boolean {
+  return effectiveBountyState(bounty, now) !== bounty.state;
+}

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,4 +1,6 @@
-export type BountyStatus = "open" | "judging" | "completed" | "draft" | "unresolved";
+import type { BountyLifecycleState } from "./bounty-state";
+
+export type BountyStatus = BountyLifecycleState | "completed";
 export type Category = "Productivity" | "Game Dev" | "Education" | "Creative" | "Tools & Utilities" | "Other";
 export type Difficulty = "Easy" | "Medium" | "Hard" | "Expert";
 

--- a/tests/bounty-state.test.ts
+++ b/tests/bounty-state.test.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+  JUDGING_WINDOW_DAYS,
+  bountyNeedsStateWriteThrough,
+  effectiveBountyState,
+  judgingWindowEndsAt,
+} from "../src/lib/bounty-state";
+
+const deadline = "2026-05-01T00:00:00.000Z";
+
+test("open bounties remain open until the deadline passes", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "open", deadline },
+      new Date("2026-04-30T23:59:59.999Z"),
+    ),
+    "open",
+  );
+});
+
+test("open bounties become judging after the deadline", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "open", deadline },
+      new Date("2026-05-01T00:00:00.001Z"),
+    ),
+    "judging",
+  );
+});
+
+test("judging bounties become unresolved after the judging window without a winner", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "judging", deadline },
+      new Date("2026-05-15T00:00:00.001Z"),
+    ),
+    "unresolved",
+  );
+});
+
+test("judging bounties stay judging during the judging window", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "judging", deadline },
+      new Date("2026-05-14T23:59:59.999Z"),
+    ),
+    "judging",
+  );
+});
+
+test("judging bounties with winners do not auto-unresolve", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "judging", deadline, winnerSelected: true },
+      new Date("2026-05-20T00:00:00.000Z"),
+    ),
+    "judging",
+  );
+});
+
+test("terminal and non-deadline states are left unchanged", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "resolved", deadline },
+      new Date("2026-05-20T00:00:00.000Z"),
+    ),
+    "resolved",
+  );
+  assert.equal(
+    effectiveBountyState(
+      { state: "hidden", deadline },
+      new Date("2026-05-20T00:00:00.000Z"),
+    ),
+    "hidden",
+  );
+});
+
+test("invalid or missing deadlines are unchanged", () => {
+  assert.equal(
+    effectiveBountyState(
+      { state: "open", deadline: "not-a-date" },
+      new Date("2026-05-20T00:00:00.000Z"),
+    ),
+    "open",
+  );
+  assert.equal(
+    effectiveBountyState(
+      { state: "judging", deadline: null },
+      new Date("2026-05-20T00:00:00.000Z"),
+    ),
+    "judging",
+  );
+});
+
+test("judging window is codified in one exported constant", () => {
+  assert.equal(JUDGING_WINDOW_DAYS, 14);
+  assert.equal(judgingWindowEndsAt(deadline)?.toISOString(), "2026-05-15T00:00:00.000Z");
+});
+
+test("write-through helper only flags changed effective states", () => {
+  assert.equal(
+    bountyNeedsStateWriteThrough(
+      { state: "open", deadline },
+      new Date("2026-05-01T00:00:00.001Z"),
+    ),
+    true,
+  );
+  assert.equal(
+    bountyNeedsStateWriteThrough(
+      { state: "open", deadline },
+      new Date("2026-04-30T23:59:59.999Z"),
+    ),
+    false,
+  );
+});


### PR DESCRIPTION

## Summary
- Adds a shared `effectiveBountyState` helper with a single 14-day judging-window constant.
- Updates bounty cards and bounty detail badges/time labels to render computed `open -> judging -> unresolved` states.
- Adds unit coverage for deadline boundaries, judging-window behavior, winner-selected behavior, invalid deadlines, and write-through detection.
- Fixes an existing lint failure in `/me` by using `next/link` for internal navigation.

## Test Plan
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- The read-through write helper is included as `bountyNeedsStateWriteThrough`, but this branch does not persist state updates yet because the bounty persistence/schema work is still blocked by issue #7. Once persisted bounties are wired in, fetch paths can call `effectiveBountyState` and write the new state when `bountyNeedsStateWriteThrough` returns true.

Closes #11
