### PR TITLE
Add public profile page

### DIFF
--- a/src/app/bounties/[id]/page.tsx
+++ b/src/app/bounties/[id]/page.tsx
@@ -70,7 +70,10 @@ export default async function BountyDetail({ params }: { params: Promise<{ id: s
                 </span>
                 <span className="flex items-center gap-1.5">
                   <span className="text-gold">★</span>
-                  Posted by <strong className="text-cream">{bounty.postedBy.name}</strong>
+                  Posted by{" "}
+                  <Link href={`/u/${bounty.postedBy.id}`} className="font-semibold text-cream hover:text-gold">
+                    {bounty.postedBy.name}
+                  </Link>
                 </span>
               </div>
             </div>

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
+import Link from "next/link";
 import { createClient } from "@/utils/supabase/server";
 import { logout } from "./actions";
 
@@ -17,7 +18,7 @@ export default async function MePage() {
         <small>User id: {data.user.id}</small>
       </p>
       <p>
-        <a href="/profile">Edit profile (placeholder)</a>
+        <Link href="/u/desertranger">View public profile</Link>
       </p>
       <form action={logout}>
         <button type="submit">Log out</button>

--- a/src/app/u/[id]/page.tsx
+++ b/src/app/u/[id]/page.tsx
@@ -1,0 +1,179 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { StatusBadge } from "@/components/status-badge";
+import { bounties, publicDemos, publicProfiles } from "@/lib/mock-data";
+
+function StatCard({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="rounded-lg bg-raised p-3">
+      <div className="text-[22px] font-bold text-cream">{value}</div>
+      <div className="mt-0.5 text-[11px] text-sand">{label}</div>
+    </div>
+  );
+}
+
+function EmptyState({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-dashed border-border bg-raised/40 px-4 py-5 text-[13px] text-sand">
+      {children}
+    </div>
+  );
+}
+
+export default async function PublicProfilePage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const profile = publicProfiles.find((candidate) => candidate.id === id);
+
+  if (!profile) {
+    notFound();
+  }
+
+  const promptsPosted = bounties.filter((bounty) => bounty.postedBy.id === profile.id);
+  const demosSubmitted = publicDemos
+    .filter((demo) => demo.rangerId === profile.id)
+    .map((demo) => ({
+      ...demo,
+      bounty: bounties.find((bounty) => bounty.id === demo.bountyId),
+    }))
+    .filter((demo) => demo.bounty);
+
+  const resolvedPrompts = promptsPosted.filter((bounty) => bounty.status === "completed").length;
+  const unresolvedPrompts = promptsPosted.filter((bounty) => bounty.status === "unresolved").length;
+  const winningDemos = demosSubmitted.filter((demo) => demo.isWinning);
+  const sheriffStars = demosSubmitted.reduce((total, demo) => total + demo.sheriffStars, 0);
+
+  return (
+    <main className="mx-auto max-w-[1280px] px-5 py-6">
+      <div className="flex flex-col gap-5 lg:flex-row">
+        <aside className="w-full shrink-0 lg:w-[300px]">
+          <div className="card p-5">
+            <div className="flex items-start gap-4">
+              <div className="flex h-[84px] w-[84px] shrink-0 items-center justify-center rounded-2xl border border-edge bg-raised text-[42px]">
+                {profile.avatarUrl}
+              </div>
+              <div className="min-w-0">
+                <h1 className="text-[22px] font-bold leading-tight text-cream">{profile.displayName}</h1>
+                <p className="text-[13px] text-gold-muted">@{profile.id}</p>
+                <p className="mt-1.5 text-[11px] text-dust">Joined {profile.joinedAt}</p>
+              </div>
+            </div>
+
+            <p className="mt-4 text-[13px] leading-relaxed text-sand">{profile.bio || "No bio yet."}</p>
+
+            <div className="mt-4 space-y-2">
+              <div className="section-label">Public Links</div>
+              {profile.links.length > 0 ? (
+                profile.links.map((link) => (
+                  <a
+                    key={link.url}
+                    href={link.url}
+                    className="flex items-center justify-between rounded-lg border border-border bg-raised px-3 py-2 text-[13px] text-sand transition-colors hover:border-edge hover:text-cream"
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    <span>{link.label}</span>
+                    <span className="text-dust">↗</span>
+                  </a>
+                ))
+              ) : (
+                <p className="text-[13px] text-dust">No public links yet.</p>
+              )}
+            </div>
+          </div>
+        </aside>
+
+        <section className="min-w-0 flex-1 space-y-5">
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatCard label="Prompts Posted" value={promptsPosted.length} />
+            <StatCard label="Resolved Prompts" value={resolvedPrompts} />
+            <StatCard label="Unresolved Prompts" value={unresolvedPrompts} />
+            <StatCard label="Demos Submitted" value={demosSubmitted.length} />
+            <StatCard label="Winning Demos" value={winningDemos.length} />
+            <StatCard label="Sheriff Stars" value={sheriffStars} />
+          </div>
+
+          <div className="grid gap-5 xl:grid-cols-2">
+            <section className="card p-5">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-[16px] font-semibold text-cream">Prompts Posted</h2>
+                <span className="text-[11px] text-dust">{promptsPosted.length} total</span>
+              </div>
+
+              {promptsPosted.length > 0 ? (
+                <ul className="space-y-3">
+                  {promptsPosted.map((bounty) => (
+                    <li key={bounty.id}>
+                      <Link href={`/bounties/${bounty.id}`} className="group block rounded-lg bg-raised p-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <h3 className="truncate text-[14px] font-semibold text-cream group-hover:text-gold">
+                              {bounty.title}
+                            </h3>
+                            <p className="mt-1 line-clamp-2 text-[12px] leading-relaxed text-sand">
+                              {bounty.description}
+                            </p>
+                          </div>
+                          <StatusBadge status={bounty.status} />
+                        </div>
+                        <div className="mt-2 flex flex-wrap gap-2 text-[11px] text-dust">
+                          <span>{bounty.category}</span>
+                          <span>•</span>
+                          <span>{bounty.rangersCount} demos</span>
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <EmptyState>This Townsfolk has not posted any prompts yet.</EmptyState>
+              )}
+            </section>
+
+            <section className="card p-5">
+              <div className="mb-4 flex items-center justify-between">
+                <h2 className="text-[16px] font-semibold text-cream">Demos Submitted</h2>
+                <span className="text-[11px] text-dust">{demosSubmitted.length} total</span>
+              </div>
+
+              {demosSubmitted.length > 0 ? (
+                <ul className="space-y-3">
+                  {demosSubmitted.map((demo) => {
+                    const bounty = demo.bounty!;
+                    return (
+                      <li key={demo.id}>
+                        <Link
+                          href={`/bounties/${bounty.id}#submission-${demo.id}`}
+                          className="group block rounded-lg bg-raised p-3"
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h3 className="truncate text-[14px] font-semibold text-cream group-hover:text-gold">
+                                  {demo.title}
+                                </h3>
+                                {demo.isWinning && (
+                                  <span className="rounded-full border border-gold-muted/50 px-2 py-0.5 text-[10px] font-semibold text-gold">
+                                    ★ Sheriff Star
+                                  </span>
+                                )}
+                              </div>
+                              <p className="mt-1 text-[12px] text-sand">For {bounty.title}</p>
+                            </div>
+                            <StatusBadge status={bounty.status} />
+                          </div>
+                          <div className="mt-2 text-[11px] text-dust">Submitted {demo.submittedAt}</div>
+                        </Link>
+                      </li>
+                    );
+                  })}
+                </ul>
+              ) : (
+                <EmptyState>This Ranger has not submitted any demos yet.</EmptyState>
+              )}
+            </section>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -4,7 +4,7 @@ const navLinks = [
   { href: "/", label: "Browse" },
   { href: "/bounties/new", label: "Post a Bounty" },
   { href: "/dashboard", label: "Dashboard" },
-  { href: "/profile/demo", label: "Profile" },
+  { href: "/u/desertranger", label: "Profile" },
 ];
 
 export function Header() {

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -13,12 +13,31 @@ export interface Bounty {
   daysLeft: number;
   rangersCount: number;
   discussionCount: number;
-  postedBy: { name: string; avatar: string };
+  postedBy: { id: string; name: string; avatar: string };
   icon: string;
   tags: string[];
   challenge?: string;
   requiredFeatures?: string[];
   acceptanceCriteria?: string[];
+}
+
+export interface PublicProfile {
+  id: string;
+  displayName: string;
+  avatarUrl: string;
+  bio: string;
+  links: { label: string; url: string }[];
+  joinedAt: string;
+}
+
+export interface PublicDemo {
+  id: string;
+  bountyId: string;
+  rangerId: string;
+  title: string;
+  submittedAt: string;
+  isWinning: boolean;
+  sheriffStars: number;
 }
 
 export interface Submission {
@@ -56,7 +75,7 @@ export const bounties: Bounty[] = [
     daysLeft: 3,
     rangersCount: 5,
     discussionCount: 12,
-    postedBy: { name: "Sheriff Bot", avatar: "🤖" },
+    postedBy: { id: "sheriff-bot", name: "Sheriff Bot", avatar: "🤖" },
     icon: "🌤️",
     tags: ["weather", "pixel-art", "api", "frontend", "mood"],
     challenge: "Build a small web app that fetches current weather for a user's location and returns a mood or vibe represented with pixel art and a short message.",
@@ -88,7 +107,7 @@ export const bounties: Bounty[] = [
     daysLeft: 5,
     rangersCount: 6,
     discussionCount: 8,
-    postedBy: { name: "CozyDev", avatar: "🏕️" },
+    postedBy: { id: "cozydev", name: "CozyDev", avatar: "🏕️" },
     icon: "🔥",
     tags: ["habits", "streaks", "productivity"],
   },
@@ -103,7 +122,7 @@ export const bounties: Bounty[] = [
     daysLeft: 2,
     rangersCount: 7,
     discussionCount: 15,
-    postedBy: { name: "PixelKnight", avatar: "⚔️" },
+    postedBy: { id: "pixelknight", name: "PixelKnight", avatar: "⚔️" },
     icon: "🎒",
     tags: ["game", "ui", "inventory", "roguelike"],
   },
@@ -118,7 +137,7 @@ export const bounties: Bounty[] = [
     daysLeft: 6,
     rangersCount: 4,
     discussionCount: 5,
-    postedBy: { name: "StudyMaster", avatar: "📚" },
+    postedBy: { id: "studymaster", name: "StudyMaster", avatar: "📚" },
     icon: "🎓",
     tags: ["ai", "education", "dashboard"],
   },
@@ -133,7 +152,7 @@ export const bounties: Bounty[] = [
     daysLeft: 1,
     rangersCount: 8,
     discussionCount: 20,
-    postedBy: { name: "NoodleFan", avatar: "🍜" },
+    postedBy: { id: "noodlefan", name: "NoodleFan", avatar: "🍜" },
     icon: "🗺️",
     tags: ["map", "food", "local"],
   },
@@ -148,9 +167,78 @@ export const bounties: Bounty[] = [
     daysLeft: 4,
     rangersCount: 6,
     discussionCount: 9,
-    postedBy: { name: "BeatDrop", avatar: "🎵" },
+    postedBy: { id: "beatdrop", name: "BeatDrop", avatar: "🎵" },
     icon: "🎧",
     tags: ["music", "creative", "mood"],
+  },
+];
+
+export const publicProfiles: PublicProfile[] = [
+  {
+    id: "desertranger",
+    displayName: "DesertRanger",
+    avatarUrl: "🤠",
+    bio: "Building useful tools, one prompt at a time. Love community, code, and a good challenge.",
+    links: [
+      { label: "GitHub", url: "https://github.com/desertranger" },
+      { label: "Portfolio", url: "https://example.com/desertranger" },
+    ],
+    joinedAt: "May 12, 2024",
+  },
+  {
+    id: "sheriff-bot",
+    displayName: "Sheriff Bot",
+    avatarUrl: "🤖",
+    bio: "Posting practice prompts and keeping the board tidy.",
+    links: [{ label: "Docs", url: "https://github.com/CaptainTimmeow/ai-bounty-board" }],
+    joinedAt: "May 3, 2026",
+  },
+  {
+    id: "newcomer",
+    displayName: "Newcomer",
+    avatarUrl: "🌵",
+    bio: "Just arrived in town.",
+    links: [],
+    joinedAt: "May 12, 2026",
+  },
+];
+
+export const publicDemos: PublicDemo[] = [
+  {
+    id: "demo-weather",
+    bountyId: "1",
+    rangerId: "desertranger",
+    title: "Pixel Weather Mood App",
+    submittedAt: "May 18, 2025",
+    isWinning: false,
+    sheriffStars: 0,
+  },
+  {
+    id: "demo-ramen",
+    bountyId: "5",
+    rangerId: "desertranger",
+    title: "Ramen Finder Map",
+    submittedAt: "May 15, 2025",
+    isWinning: true,
+    sheriffStars: 1,
+  },
+  {
+    id: "demo-inventory",
+    bountyId: "3",
+    rangerId: "desertranger",
+    title: "Roguelike Inventory UI",
+    submittedAt: "May 12, 2025",
+    isWinning: false,
+    sheriffStars: 0,
+  },
+  {
+    id: "demo-study",
+    bountyId: "4",
+    rangerId: "desertranger",
+    title: "AI Study Buddy",
+    submittedAt: "May 8, 2025",
+    isWinning: true,
+    sheriffStars: 1,
   },
 ];
 


### PR DESCRIPTION
## Summary
- add public /u/[id] profile route with profile fields, stats, posted prompts, and submitted demos
- show Sheriff Star badges on winning demos and graceful empty states for zero-activity profiles
- link existing profile entry points and bounty posters to the public profile route

Closes #14.

## Notes
The current main branch only has the profiles table merged; bounties/submissions are still represented by the existing mock data in this UI. This keeps the route aligned with the current app surface without reading auth.users directly.

## Verification
- npm run lint
- npm run build
- curl -I http://localhost:3004/u/desertranger -> 200
- curl -I http://localhost:3004/u/newcomer -> 200
- curl -I http://localhost:3004/u/unknown-profile -> 404